### PR TITLE
Add referral url

### DIFF
--- a/react-ui/src/api/startSession.ts
+++ b/react-ui/src/api/startSession.ts
@@ -6,9 +6,12 @@ const startSession = async (): Promise<IStartSessionResponse | undefined> => {
   const headers = {
     "Content-Type": "application/json",
   };
+  const body = JSON.stringify({
+    referralUrl: window.location.href
+  });
   try {
     const res = (await (
-      await fetch(url, { method, headers })
+      await fetch(url, { body, method, headers })
     ).json()) as IStartSessionResponse;
     console.log("res", res);
     return res;

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ const App = () => {
 
       const newSession = new SessionResults({
         createdAt: new Date(),
+        referralUrl: req.body.referralUrl ?? '',
       })
 
       newSession.save(function (error, document) {
@@ -274,7 +275,7 @@ const App = () => {
 
     // POSTS
     app.post('/api/import-questions', jsonParser, importQuestions);
-    app.post('/api/start-session', startSession)
+    app.post('/api/start-session', jsonParser, startSession)
     app.post('/api/get-answer-percent', jsonParser, getAnswerPercent)
 
     // PUT

--- a/server/models/SessionResults.js
+++ b/server/models/SessionResults.js
@@ -9,6 +9,7 @@ const SessionResultsSchema = new Schema({
     answerId: String,
   }],
   email: String,
+  referralUrl: String,
   sessionId: String,
   archetype: String,
   scores: {


### PR DESCRIPTION
Add a new key to SessionResults schema for referralURL. And update front end call to pass current url when a new session is started. 
In this way we can have multiple urls active simultaneously for example (quiz.homex.com/internal, quiz.homex.com/reddit etc) and then can filter the db based on where the traffic came from. 